### PR TITLE
clear waypoints from Rviz on path reset

### DIFF
--- a/src/follow_waypoints/follow_waypoints.py
+++ b/src/follow_waypoints/follow_waypoints.py
@@ -151,6 +151,7 @@ class Commander(object):
                 self.move_base_client.wait_for_result()
                 info("Waiting for %f sec..." % self.wait_duration)
                 time.sleep(self.wait_duration)
+                self.pose_array_publisher.publish(toPoseArray(self.waypoints))
             else:
                 raise NotImplementedError("distance_tolerance not implemented yet.")
 

--- a/src/follow_waypoints/follow_waypoints.py
+++ b/src/follow_waypoints/follow_waypoints.py
@@ -61,7 +61,7 @@ class Commander(object):
 
         # Publish waypoints as pose array - visualise them in rviz
         self.pose_array_publisher = rospy.Publisher(
-            self.waypoints_list_topic, PoseArray, queue_size=1
+            self.waypoints_list_topic, PoseArray, queue_size=1, latch=True
         )
 
         # Listen to the goal locations
@@ -85,6 +85,7 @@ class Commander(object):
 
         if self.waypoints:
             self.waypoints = []
+            self.pose_array_publisher.publish(toPoseArray(self.waypoints))
 
         return (True, "")
 


### PR DESCRIPTION
I have started using your fork and I am extremely happy with it, since it fixed the bug in which the first waypoint was added to the waypoints array multiple times.
I have made some changes to improve on the visualization of the waypoints on Rviz. The first one is latching the waypoints topic, so if Rviz starts, after the follow_waypoints node it will still receive the waypoints. And the other is, deleting the waypoints on Rviz on path reset, so it will reflect the state of the node.
Thanks a lot for your great improvements!
